### PR TITLE
feat: add gpt-image-2 support with flexible custom sizes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,7 @@ PROVIDERS__GEMINI__DEFAULT_MODEL=imagen-4
 # =============================================================================
 # Image Generation Settings
 # =============================================================================
-IMAGES__DEFAULT_MODEL=gpt-image-1.5
+IMAGES__DEFAULT_MODEL=gpt-image-2
 IMAGES__DEFAULT_QUALITY=auto
 IMAGES__DEFAULT_SIZE=1536x1024
 IMAGES__DEFAULT_STYLE=vivid

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Traditional AI chatbot interfaces are limited to text-only interactions, regardless of how powerful their underlying language models are. Image Gen MCP Server bridges this gap by enabling **any LLM-powered chatbot client** to generate professional-quality images through the standardized Model Context Protocol (MCP).
 
-Whether you're using Claude Desktop, a custom ChatGPT interface, Llama-based applications, or any other LLM client that supports MCP, this server democratizes access to **multiple AI image generation models** including OpenAI's gpt-image-1, dall-e-3, dall-e-2, and Google's Imagen series (imagen-4, imagen-4-ultra, imagen-3), transforming text-only conversations into rich, visual experiences.
+Whether you're using Claude Desktop, a custom ChatGPT interface, Llama-based applications, or any other LLM client that supports MCP, this server democratizes access to **multiple AI image generation models** including OpenAI's gpt-image-2, gpt-image-1.5, gpt-image-1, dall-e-3, dall-e-2, and Google's Imagen series (imagen-4, imagen-4-ultra, imagen-4-fast, imagen-3), transforming text-only conversations into rich, visual experiences.
 
 > **📦 Package Manager**: This project uses [UV](https://docs.astral.sh/uv/) for fast, reliable Python package management. UV provides better dependency resolution, faster installs, and proper environment isolation compared to traditional pip/venv workflows.
 
@@ -71,7 +71,7 @@ The AI ecosystem has evolved to include powerful language models from multiple p
 ## Features
 
 ### 🎨 Multi-Provider Image Generation
-- **Multiple AI Models**: Support for OpenAI (gpt-image-1, dall-e-3, dall-e-2) and Google Gemini (imagen-4, imagen-4-ultra, imagen-3)
+- **Multiple AI Models**: Support for OpenAI (gpt-image-2, gpt-image-1.5, gpt-image-1, dall-e-3, dall-e-2) and Google Gemini (imagen-4, imagen-4-ultra, imagen-4-fast, imagen-3)
 - **Text-to-Image**: Generate high-quality images from text descriptions
 - **Image Editing**: Edit existing images with text instructions (OpenAI models)
 - **Multiple Formats**: Support for PNG, JPEG, and WebP output formats
@@ -190,7 +190,7 @@ uv run python -m image_gen_mcp.server --transport streamable-http --cors
 ```bash
 uv run python -m image_gen_mcp.server --help
 
-Image Gen MCP Server - Generate and edit images using OpenAI's gpt-image-1 model
+Image Gen MCP Server - Generate and edit images using OpenAI's gpt-image models and Google's Imagen series
 
 options:
   --config PATH         Path to configuration file (.env format)
@@ -331,9 +331,9 @@ Generate images from text descriptions using any supported model.
 
 **Parameters**:
 - `prompt` (required): Text description of desired image
-- `model` (optional): Model to use (e.g., "gpt-image-1", "dall-e-3", "imagen-4")
+- `model` (optional): Model to use (e.g., "gpt-image-2", "gpt-image-1.5", "dall-e-3", "imagen-4")
 - `quality`: "auto" | "high" | "medium" | "low" (default: "auto")
-- `size`: "1024x1024" | "1536x1024" | "1024x1536" (default: "1536x1024")
+- `size`: "auto", presets like "1024x1024" / "1536x1024" / "1024x1536" / "3840x2160", or (for `gpt-image-2`) any `WxH` within the model's constraints (default: "1536x1024"). Accepted values are model-dependent.
 - `style`: "vivid" | "natural" (default: "vivid")
 - `output_format`: "png" | "jpeg" | "webp" (default: "png")
 - `background`: "auto" | "transparent" | "opaque" (default: "auto")
@@ -354,7 +354,7 @@ Edit existing images with text instructions.
 - `generated-images://{image_id}` - Access specific generated images
 - `image-history://recent` - Browse recent generation history
 - `storage-stats://overview` - Storage usage and statistics
-- `model-info://gpt-image-1` - Model capabilities and pricing
+- `model-info://gpt-image-2` - Model capabilities and pricing (also available for gpt-image-1.5, gpt-image-1, dall-e-3, dall-e-2)
 
 ## Prompt Templates
 
@@ -404,7 +404,7 @@ PROVIDERS__GEMINI__DEFAULT_MODEL=imagen-4
 # =============================================================================
 # Image Generation Settings
 # =============================================================================
-IMAGES__DEFAULT_MODEL=gpt-image-1
+IMAGES__DEFAULT_MODEL=gpt-image-2
 IMAGES__DEFAULT_QUALITY=auto
 IMAGES__DEFAULT_SIZE=1536x1024
 IMAGES__DEFAULT_STYLE=vivid
@@ -620,7 +620,7 @@ For issues and questions:
 
 ---
 
-**Built with ❤️ using the Model Context Protocol and OpenAI's gpt-image-1**
+**Built with ❤️ using the Model Context Protocol and OpenAI's gpt-image-2**
 
 ## The Future of AI Integration
 

--- a/SYSTEM_DESIGN.md
+++ b/SYSTEM_DESIGN.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document provides a comprehensive technical overview of the Image Gen MCP Server, a Model Context Protocol (MCP) server that integrates OpenAI's gpt-image-1 model for text-to-image generation services.
+This document provides a comprehensive technical overview of the Image Gen MCP Server, a Model Context Protocol (MCP) server that integrates OpenAI's gpt-image family (gpt-image-2, gpt-image-1.5, gpt-image-1), DALL-E, and Google's Imagen series for text-to-image generation and editing services.
 
 ## Architecture
 
@@ -93,9 +93,9 @@ redis  # Optional caching backend
 
 ### OpenAI Images API Integration
 
-#### Model: gpt-image-1
+#### Models: gpt-image-2 / gpt-image-1.5 / gpt-image-1
 
-The server integrates with OpenAI's latest image generation model using the correct Images API endpoints:
+The server integrates with OpenAI's image generation models using the Images API endpoints. `gpt-image-2` is the current default — it adds flexible sizing (any `WxH` where both edges are multiples of 16, max edge 3840px, aspect ≤3:1), supports 4K output (`3840x2160`), and is cheaper than gpt-image-1.5 ($30 vs $32 per 1M image output tokens).
 
 #### 1. Image Generation Endpoint
 
@@ -722,7 +722,7 @@ PROVIDERS__GEMINI__DEFAULT_MODEL=imagen-4
 # =============================================================================
 # Image Generation Settings
 # =============================================================================
-IMAGES__DEFAULT_MODEL=gpt-image-1
+IMAGES__DEFAULT_MODEL=gpt-image-2
 IMAGES__DEFAULT_QUALITY=auto
 IMAGES__DEFAULT_SIZE=1536x1024
 IMAGES__DEFAULT_STYLE=vivid

--- a/docs/openai_images_api_guide.md
+++ b/docs/openai_images_api_guide.md
@@ -30,7 +30,7 @@ Creates an image given a prompt. [Learn more](https://platform.openai.com/docs/g
 | `quality` | string | No | Image quality. `gpt-image-*`: `auto`, `high`, `medium`, `low`. `dall-e-3`: `hd` or `standard` |
 | `style` | string | No | Style for `dall-e-3`: `vivid` or `natural` |
 | `output_format` | string | No | Format for `gpt-image-*`: `png`, `jpeg`, or `webp` |
-| `background` | string | No | Background. `gpt-image-1` / `gpt-image-1.5`: `transparent`, `opaque`, `auto`. `gpt-image-2`: `opaque` or `auto` only (transparent is not supported) |
+| `background` | string | No | Background. `gpt-image-1` / `gpt-image-1.5`: `transparent`, `opaque`, `auto`. `gpt-image-2`: accepts the same values, but `transparent` is auto-downgraded to `auto` since gpt-image-2 has no native transparency support |
 | `moderation` | string | No | Moderation level for `gpt-image-*`: `auto` or `low` |
 
 ### Example Request

--- a/docs/openai_images_api_guide.md
+++ b/docs/openai_images_api_guide.md
@@ -30,7 +30,7 @@ Creates an image given a prompt. [Learn more](https://platform.openai.com/docs/g
 | `quality` | string | No | Image quality. `gpt-image-*`: `auto`, `high`, `medium`, `low`. `dall-e-3`: `hd` or `standard` |
 | `style` | string | No | Style for `dall-e-3`: `vivid` or `natural` |
 | `output_format` | string | No | Format for `gpt-image-*`: `png`, `jpeg`, or `webp` |
-| `background` | string | No | Background for `gpt-image-*`: `transparent`, `opaque`, or `auto` |
+| `background` | string | No | Background. `gpt-image-1` / `gpt-image-1.5`: `transparent`, `opaque`, `auto`. `gpt-image-2`: `opaque` or `auto` only (transparent is not supported) |
 | `moderation` | string | No | Moderation level for `gpt-image-*`: `auto` or `low` |
 
 ### Example Request

--- a/docs/openai_images_api_guide.md
+++ b/docs/openai_images_api_guide.md
@@ -7,7 +7,9 @@ This guide covers the OpenAI Images API integration used by the Image Gen MCP Se
 ## Quick Reference
 
 The Image Gen MCP Server supports the following OpenAI models:
-- **gpt-image-1**: Latest image generation model with advanced features
+- **gpt-image-2**: Current flagship — flexible sizing up to 4K (3840x2160), $30/1M image output tokens
+- **gpt-image-1.5**: Previous flagship with fixed preset sizes
+- **gpt-image-1**: Original gpt-image model
 - **dall-e-3**: High-quality creative image generation
 - **dall-e-2**: Standard image generation with editing capabilities
 
@@ -21,15 +23,15 @@ Creates an image given a prompt. [Learn more](https://platform.openai.com/docs/g
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `prompt` | string | Yes | Text description of the desired image(s). Max 32000 characters for `gpt-image-1`, 1000 for `dall-e-2`, 4000 for `dall-e-3` |
-| `model` | string | No | Model to use: `gpt-image-1`, `dall-e-3`, or `dall-e-2` (default) |
-| `n` | integer | No | Number of images (1-10). For `dall-e-3`, only `n=1` is supported |
-| `size` | string | No | Image size. For `gpt-image-1`: `1024x1024`, `1536x1024`, `1024x1536`, or `auto` |
-| `quality` | string | No | Image quality. For `gpt-image-1`: `auto`, `high`, `medium`, `low` |
+| `prompt` | string | Yes | Text description of the desired image(s). Max 32,000 chars for `gpt-image-*`, 1,000 for `dall-e-2`, 4,000 for `dall-e-3` |
+| `model` | string | No | Model to use: `gpt-image-2` (default), `gpt-image-1.5`, `gpt-image-1`, `dall-e-3`, or `dall-e-2` |
+| `n` | integer | No | Number of images. `gpt-image-*` and `dall-e-3`: `n=1` only. `dall-e-2`: up to 10 |
+| `size` | string | No | Image size. `gpt-image-1` / `gpt-image-1.5`: `1024x1024`, `1536x1024`, `1024x1536`, or `auto`. `gpt-image-2`: presets plus `3840x2160` and any `WxH` (multiples of 16, max edge 3840, aspect ≤3:1, 655,360–8,294,400 pixels) |
+| `quality` | string | No | Image quality. `gpt-image-*`: `auto`, `high`, `medium`, `low`. `dall-e-3`: `hd` or `standard` |
 | `style` | string | No | Style for `dall-e-3`: `vivid` or `natural` |
-| `output_format` | string | No | Format for `gpt-image-1`: `png`, `jpeg`, or `webp` |
-| `background` | string | No | Background for `gpt-image-1`: `transparent`, `opaque`, or `auto` |
-| `moderation` | string | No | Moderation level for `gpt-image-1`: `auto` or `low` |
+| `output_format` | string | No | Format for `gpt-image-*`: `png`, `jpeg`, or `webp` |
+| `background` | string | No | Background for `gpt-image-*`: `transparent`, `opaque`, or `auto` |
+| `moderation` | string | No | Moderation level for `gpt-image-*`: `auto` or `low` |
 
 ### Example Request
 
@@ -38,7 +40,7 @@ curl https://api.openai.com/v1/images/generations \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $PROVIDERS__OPENAI__API_KEY" \
   -d '{
-    "model": "gpt-image-1",
+    "model": "gpt-image-2",
     "prompt": "A cute baby sea otter",
     "n": 1,
     "size": "1024x1024"
@@ -53,7 +55,7 @@ from openai import OpenAI
 client = OpenAI()
 
 img = client.images.generate(
-    model="gpt-image-1",
+    model="gpt-image-2",
     prompt="A cute baby sea otter",
     n=1,
     size="1024x1024"
@@ -68,15 +70,15 @@ with open("output.png", "wb") as f:
 
 **Endpoint**: `POST https://api.openai.com/v1/images/edits`
 
-Creates an edited or extended image given source images and a prompt. Only supports `gpt-image-1` and `dall-e-2`.
+Creates an edited or extended image given source images and a prompt. Supports `gpt-image-*` (recommend `gpt-image-2`) and `dall-e-2`.
 
 ### Request Body
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `image` | file/array | Yes | Image(s) to edit. For `gpt-image-1`: up to 16 images, PNG/WEBP/JPG < 50MB |
-| `prompt` | string | Yes | Edit instructions. Max 32000 characters for `gpt-image-1`, 1000 for `dall-e-2` |
-| `model` | string | No | Model to use: `gpt-image-1` or `dall-e-2` (default) |
+| `image` | file/array | Yes | Image(s) to edit. For `gpt-image-*`: up to 16 images, PNG/WEBP/JPG < 50MB |
+| `prompt` | string | Yes | Edit instructions. Max 32,000 chars for `gpt-image-*`, 1,000 for `dall-e-2` |
+| `model` | string | No | Model to use: `gpt-image-2` (default), `gpt-image-1.5`, `gpt-image-1`, or `dall-e-2` |
 | `mask` | file | No | PNG mask file indicating areas to edit |
 | `n` | integer | No | Number of images to generate (1-10) |
 
@@ -85,7 +87,7 @@ Creates an edited or extended image given source images and a prompt. Only suppo
 ```bash
 curl -X POST "https://api.openai.com/v1/images/edits" \
   -H "Authorization: Bearer $PROVIDERS__OPENAI__API_KEY" \
-  -F "model=gpt-image-1" \
+  -F "model=gpt-image-2" \
   -F "image[]=@body-lotion.png" \
   -F "image[]=@bath-bomb.png" \
   -F 'prompt=Create a lovely gift basket with these items'
@@ -109,7 +111,7 @@ PROVIDERS__OPENAI__ENABLED=true
 # Generate with OpenAI model
 result = await session.call_tool("generate_image", {
     "prompt": "A beautiful sunset over mountains",
-    "model": "gpt-image-1",
+    "model": "gpt-image-2",
     "quality": "high",
     "size": "1536x1024"
 })
@@ -122,7 +124,7 @@ result = await session.call_tool("generate_image", {
 result = await session.call_tool("edit_image", {
     "image_data": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...",
     "prompt": "Add a rainbow to the sky",
-    "model": "gpt-image-1"
+    "model": "gpt-image-2"
 })
 ```
 
@@ -130,6 +132,8 @@ result = await session.call_tool("edit_image", {
 
 | Model | Generation | Editing | Max Prompt | Sizes | Quality Options |
 |-------|------------|---------|------------|-------|----------------|
+| gpt-image-2 | ✅ | ✅ | 32,000 chars | Presets + any WxH (mult-of-16, max edge 3840, aspect ≤3:1) | auto, high, medium, low |
+| gpt-image-1.5 | ✅ | ✅ | 32,000 chars | 1024x1024, 1536x1024, 1024x1536 | auto, high, medium, low |
 | gpt-image-1 | ✅ | ✅ | 32,000 chars | 1024x1024, 1536x1024, 1024x1536 | auto, high, medium, low |
 | dall-e-3 | ✅ | ❌ | 4,000 chars | 1024x1024, 1792x1024, 1024x1792 | hd, standard |
 | dall-e-2 | ✅ | ✅ | 1,000 chars | 256x256, 512x512, 1024x1024 | standard |
@@ -163,7 +167,7 @@ Common error codes:
 ## Best Practices
 
 1. **Model Selection**: 
-   - Use `gpt-image-1` for best quality and features
+   - Use `gpt-image-2` for best quality, flexible sizing (incl. 4K), and lowest per-image cost
    - Use `dall-e-3` for creative, artistic images
    - Use `dall-e-2` for simple images or editing
 

--- a/image_gen_mcp/config/settings.py
+++ b/image_gen_mcp/config/settings.py
@@ -133,12 +133,17 @@ class ProvidersSettings(BaseModel):
 class ImageSettings(BaseModel):
     """Image generation default settings."""
 
-    default_model: str = Field("gpt-image-1.5", description="Default image model")
+    default_model: str = Field("gpt-image-2", description="Default image model")
     default_quality: Literal["auto", "high", "medium", "low"] = Field(
         "auto", description="Default quality"
     )
-    default_size: Literal["1024x1024", "1536x1024", "1024x1536", "auto"] = Field(
-        "1536x1024", description="Default size"
+    default_size: str = Field(
+        "1536x1024",
+        description=(
+            "Default image size. Accepts 'auto', presets like '1024x1024' / "
+            "'1536x1024' / '1024x1536' / '3840x2160', or any 'WxH' supported "
+            "by the configured model (validated at request time)."
+        ),
     )
     default_style: Literal["vivid", "natural"] = Field(
         "vivid", description="Default style"

--- a/image_gen_mcp/config/settings.py
+++ b/image_gen_mcp/config/settings.py
@@ -1,5 +1,6 @@
 """Configuration settings for the Image Gen MCP Server."""
 
+import re
 from pathlib import Path
 from typing import Literal
 
@@ -163,6 +164,33 @@ class ImageSettings(BaseModel):
             "Base URL for image hosting (for nginx/CDN), if None uses MCP server host"
         ),
     )
+
+    @field_validator("default_size")
+    @classmethod
+    def _validate_default_size(cls, v: str) -> str:
+        """Reject malformed sizes at startup.
+
+        Accepts 'auto' or a well-formed 'WxH' string (two positive integers
+        separated by 'x'). Model-specific constraints (multiples of 16,
+        aspect ratio, pixel count) are enforced by the provider at request
+        time so custom sizes for gpt-image-2 still flow through.
+        """
+        if not isinstance(v, str):
+            raise ValueError("default_size must be a string")
+        normalized = v.strip().lower()
+        if normalized == "auto":
+            return normalized
+        if not re.fullmatch(r"\d+x\d+", normalized):
+            raise ValueError(
+                f"default_size must be 'auto' or 'WxH' "
+                f"(e.g. '1024x1024', '2048x1152'); got {v!r}"
+            )
+        w, h = (int(p) for p in normalized.split("x"))
+        if w <= 0 or h <= 0:
+            raise ValueError(
+                f"default_size dimensions must be positive; got {v!r}"
+            )
+        return normalized
 
 
 class StorageSettings(BaseModel):

--- a/image_gen_mcp/providers/base.py
+++ b/image_gen_mcp/providers/base.py
@@ -57,6 +57,8 @@ class ModelCapability:
     supports_style: bool = False
     supports_background: bool = False
     supports_compression: bool = False
+    supports_custom_sizes: bool = False
+    size_constraints: dict[str, Any] | None = None
     custom_parameters: dict[str, Any] = field(default_factory=dict)
 
 
@@ -142,7 +144,11 @@ class LLMProvider(ABC):
             )
 
         # Validate size parameter
-        if "size" in params and params["size"] not in capabilities.supported_sizes:
+        if (
+            "size" in params
+            and params["size"] not in capabilities.supported_sizes
+            and not capabilities.supports_custom_sizes
+        ):
             self._logger.warning(
                 f"Size '{params['size']}' not in supported sizes "
                 f"{capabilities.supported_sizes} for model {model}. "

--- a/image_gen_mcp/providers/openai.py
+++ b/image_gen_mcp/providers/openai.py
@@ -137,9 +137,12 @@ class OpenAIProvider(LLMProvider):
         },
         custom_parameters={
             "moderation": ["auto", "low"],
-            # gpt-image-2 does not support transparent backgrounds.
-            # Ref: https://developers.openai.com/api/docs/guides/image-generation
-            "background": ["auto", "opaque"],
+            # gpt-image-2 does not natively support transparent backgrounds
+            # (OpenAI docs), but callers may pass 'transparent' — it is
+            # transparently downgraded to 'auto' on every outbound path via
+            # OpenAIProvider._resolve_background so the public interface
+            # stays uniform across models.
+            "background": ["auto", "transparent", "opaque"],
         },
     )
 

--- a/image_gen_mcp/providers/openai.py
+++ b/image_gen_mcp/providers/openai.py
@@ -18,9 +18,21 @@ from .base import (
 logger = logging.getLogger(__name__)
 
 
+# Per-image output token approximations at 1024x1024, sampled from OpenAI's
+# image-generation calculator. Token cost scales roughly linearly with pixel
+# count at a given quality tier. These are ROUGH and only intended to give
+# callers an order-of-magnitude estimate — the actual calculator uses a more
+# complex model we don't replicate here.
+_GPT_IMAGE_2_TOKENS_BASE_1024: dict[str, int] = {
+    "low": 170,       # ≈ $0.005 at $30/1M
+    "medium": 1370,   # ≈ $0.041
+    "high": 5500,     # ≈ $0.165
+    "auto": 1370,     # treat auto as medium for estimation
+}
+
 # Token pricing for gpt-image-* models. Shared with OpenAIClientManager so
 # pricing lives in one place.
-GPT_IMAGE_TOKEN_PRICING: dict[str, dict[str, float]] = {
+GPT_IMAGE_TOKEN_PRICING: dict[str, dict[str, Any]] = {
     "gpt-image-1": {
         "text_input_per_1m_tokens": 5.0,
         "image_output_per_1m_tokens": 40.0,
@@ -34,9 +46,52 @@ GPT_IMAGE_TOKEN_PRICING: dict[str, dict[str, float]] = {
     "gpt-image-2": {
         "text_input_per_1m_tokens": 5.0,
         "image_output_per_1m_tokens": 30.0,
-        "tokens_per_image": 1750,
+        "tokens_per_image_by_quality": _GPT_IMAGE_2_TOKENS_BASE_1024,
     },
 }
+
+
+def _parse_pixels(size: str) -> int | None:
+    """Parse a 'WxH' size string and return W*H. None on failure or 'auto'."""
+    if not isinstance(size, str):
+        return None
+    normalized = size.strip().lower()
+    if normalized == "auto" or "x" not in normalized:
+        return None
+    try:
+        w_str, h_str = normalized.split("x", 1)
+        w, h = int(w_str), int(h_str)
+    except (ValueError, TypeError):
+        return None
+    if w <= 0 or h <= 0:
+        return None
+    return w * h
+
+
+def _gpt_image_2_tokens_per_image(quality: str, size: str) -> int:
+    """Approximate output tokens for a single gpt-image-2 image.
+
+    Uses the quality-tier baseline at 1024x1024 with a sub-linear size
+    multiplier: scales linearly *down* for smaller images but caps the
+    upscale at ~1.3x. This matches the OpenAI calculator, which prices
+    high-quality 4K at only ~28% more than high-quality 1024x1024 despite
+    the 7.9x pixel ratio.
+
+    Unknown quality falls back to the auto/medium tier; auto/unparseable
+    size uses the 1024x1024 baseline unchanged.
+    """
+    base = _GPT_IMAGE_2_TOKENS_BASE_1024.get(
+        (quality or "auto").lower(),
+        _GPT_IMAGE_2_TOKENS_BASE_1024["auto"],
+    )
+    pixels = _parse_pixels(size)
+    if pixels is None:
+        return base
+    ratio = pixels / (1024 * 1024)
+    # Scale down linearly below 1024² (small sizes cost less); cap the
+    # upscale at 1.3x to match the observed calculator flattening.
+    multiplier = ratio if ratio < 1.0 else min(ratio, 1.3)
+    return max(1, int(base * multiplier))
 
 
 class OpenAIProvider(LLMProvider):
@@ -82,7 +137,9 @@ class OpenAIProvider(LLMProvider):
         },
         custom_parameters={
             "moderation": ["auto", "low"],
-            "background": ["auto", "transparent", "opaque"],
+            # gpt-image-2 does not support transparent backgrounds.
+            # Ref: https://developers.openai.com/api/docs/guides/image-generation
+            "background": ["auto", "opaque"],
         },
     )
 
@@ -192,6 +249,25 @@ class OpenAIProvider(LLMProvider):
         """Get capabilities for a specific OpenAI model."""
         return self.SUPPORTED_MODELS.get(model_id)
 
+    @classmethod
+    def _resolve_background(cls, background: str, model: str) -> str:
+        """Downgrade unsupported background values per model.
+
+        gpt-image-2 does not support transparent backgrounds per OpenAI
+        docs; callers that request it get 'auto' instead with a warning.
+        """
+        if (
+            model == "gpt-image-2"
+            and isinstance(background, str)
+            and background.strip().lower() == "transparent"
+        ):
+            logger.warning(
+                "background='transparent' is not supported by gpt-image-2; "
+                "using 'auto' instead"
+            )
+            return "auto"
+        return background
+
     def validate_model_params(
         self, model: str, params: dict[str, Any]
     ) -> dict[str, Any]:
@@ -276,7 +352,9 @@ class OpenAIProvider(LLMProvider):
         # Add gpt-image specific parameters (not supported by DALL-E)
         if model.startswith("gpt-image-"):
             request_params["output_format"] = output_format
-            request_params["background"] = background
+            request_params["background"] = self._resolve_background(
+                background, model
+            )
             if output_format in ["jpeg", "webp"] and compression < 100:
                 request_params["output_compression"] = compression
 
@@ -389,7 +467,9 @@ class OpenAIProvider(LLMProvider):
         if model.startswith("gpt-image-"):
             request_params["quality"] = quality
             request_params["output_format"] = output_format
-            request_params["background"] = background
+            request_params["background"] = self._resolve_background(
+                background, model
+            )
             if output_format in ["jpeg", "webp"] and compression < 100:
                 request_params["output_compression"] = compression
 
@@ -477,9 +557,21 @@ class OpenAIProvider(LLMProvider):
             )
 
     def estimate_cost(
-        self, model: str, prompt: str, image_count: int = 1
+        self,
+        model: str,
+        prompt: str,
+        image_count: int = 1,
+        quality: str = "auto",
+        size: str = "1024x1024",
     ) -> dict[str, Any]:
-        """Estimate cost for OpenAI image generation."""
+        """Estimate cost for OpenAI image generation.
+
+        For gpt-image-2, output tokens vary substantially by quality and
+        size, so the estimate uses a quality-tiered baseline that scales
+        linearly with pixel count. Results are marked with
+        ``estimate_accuracy: "rough"`` — callers should not rely on these
+        as authoritative billing figures.
+        """
 
         fixed_pricing = {
             "dall-e-3": {"cost_per_image": 0.04},
@@ -492,8 +584,15 @@ class OpenAIProvider(LLMProvider):
             text_cost = (text_tokens / 1_000_000) * model_pricing[
                 "text_input_per_1m_tokens"
             ]
+
+            if model == "gpt-image-2":
+                tokens_per_image = _gpt_image_2_tokens_per_image(quality, size)
+            else:
+                tokens_per_image = model_pricing["tokens_per_image"]
+
+            image_tokens_total = tokens_per_image * image_count
             image_cost = (
-                image_count * model_pricing["tokens_per_image"] / 1_000_000
+                image_tokens_total / 1_000_000
             ) * model_pricing["image_output_per_1m_tokens"]
             total_cost = text_cost + image_cost
 
@@ -502,11 +601,15 @@ class OpenAIProvider(LLMProvider):
                 "model": model,
                 "estimated_cost_usd": round(total_cost, 4),
                 "currency": "USD",
+                "estimate_accuracy": "rough",
                 "breakdown": {
                     "text_input_cost": round(text_cost, 4),
                     "image_output_cost": round(image_cost, 4),
                     "text_tokens": int(text_tokens),
-                    "image_tokens": model_pricing["tokens_per_image"] * image_count,
+                    "image_tokens": image_tokens_total,
+                    "tokens_per_image": tokens_per_image,
+                    "quality": quality,
+                    "size": size,
                     "total_images": image_count,
                 },
             }

--- a/image_gen_mcp/providers/openai.py
+++ b/image_gen_mcp/providers/openai.py
@@ -18,6 +18,27 @@ from .base import (
 logger = logging.getLogger(__name__)
 
 
+# Token pricing for gpt-image-* models. Shared with OpenAIClientManager so
+# pricing lives in one place.
+GPT_IMAGE_TOKEN_PRICING: dict[str, dict[str, float]] = {
+    "gpt-image-1": {
+        "text_input_per_1m_tokens": 5.0,
+        "image_output_per_1m_tokens": 40.0,
+        "tokens_per_image": 1750,
+    },
+    "gpt-image-1.5": {
+        "text_input_per_1m_tokens": 4.0,
+        "image_output_per_1m_tokens": 32.0,
+        "tokens_per_image": 1750,
+    },
+    "gpt-image-2": {
+        "text_input_per_1m_tokens": 5.0,
+        "image_output_per_1m_tokens": 30.0,
+        "tokens_per_image": 1750,
+    },
+}
+
+
 class OpenAIProvider(LLMProvider):
     """OpenAI provider for image generation using gpt-image and DALL-E models."""
 
@@ -36,6 +57,35 @@ class OpenAIProvider(LLMProvider):
         },
     )
 
+    # gpt-image-2 adds flexible sizing up to 4K
+    _GPT_IMAGE_2_CAPABILITY = dict(
+        supported_sizes=[
+            "auto",
+            "1024x1024",
+            "1536x1024",
+            "1024x1536",
+            "3840x2160",
+        ],
+        supported_qualities=["auto", "high", "medium", "low"],
+        supported_formats=["png", "jpeg", "webp"],
+        max_images_per_request=1,
+        supports_style=False,
+        supports_background=True,
+        supports_compression=True,
+        supports_custom_sizes=True,
+        size_constraints={
+            "multiple_of": 16,
+            "max_edge": 3840,
+            "max_aspect_ratio": 3.0,
+            "min_pixels": 655_360,
+            "max_pixels": 8_294_400,
+        },
+        custom_parameters={
+            "moderation": ["auto", "low"],
+            "background": ["auto", "transparent", "opaque"],
+        },
+    )
+
     # Supported models and their capabilities
     SUPPORTED_MODELS = {
         "gpt-image-1": ModelCapability(
@@ -45,6 +95,10 @@ class OpenAIProvider(LLMProvider):
         "gpt-image-1.5": ModelCapability(
             model_id="gpt-image-1.5",
             **_GPT_IMAGE_CAPABILITY,
+        ),
+        "gpt-image-2": ModelCapability(
+            model_id="gpt-image-2",
+            **_GPT_IMAGE_2_CAPABILITY,
         ),
         "dall-e-3": ModelCapability(
             model_id="dall-e-3",
@@ -86,9 +140,88 @@ class OpenAIProvider(LLMProvider):
         """Return set of supported OpenAI model IDs."""
         return set(self.SUPPORTED_MODELS.keys())
 
+    @staticmethod
+    def _validate_custom_size(size: str, constraints: dict[str, Any]) -> bool:
+        """Check a WxH string against a model's custom-size constraints."""
+        try:
+            w_str, h_str = size.lower().split("x")
+            w, h = int(w_str), int(h_str)
+        except (ValueError, AttributeError):
+            return False
+        if w <= 0 or h <= 0:
+            return False
+        multiple_of = constraints["multiple_of"]
+        if w % multiple_of or h % multiple_of:
+            return False
+        if max(w, h) > constraints["max_edge"]:
+            return False
+        if max(w, h) / min(w, h) > constraints["max_aspect_ratio"]:
+            return False
+        pixels = w * h
+        return constraints["min_pixels"] <= pixels <= constraints["max_pixels"]
+
+    @classmethod
+    def _resolve_size(
+        cls, size: str, capabilities: ModelCapability, model: str
+    ) -> str:
+        """Return a size string the API will accept, falling back to auto.
+
+        Normalizes whitespace and case up-front so cache keys, metadata, and
+        outbound requests all see the same canonical value regardless of
+        caller input (e.g. ``"  1600X896 "`` → ``"1600x896"``).
+        """
+        normalized = size.strip().lower() if isinstance(size, str) else size
+        if normalized in capabilities.supported_sizes:
+            return normalized
+        if (
+            capabilities.supports_custom_sizes
+            and capabilities.size_constraints
+            and cls._validate_custom_size(normalized, capabilities.size_constraints)
+        ):
+            return normalized
+        fallback = (
+            "auto" if "auto" in capabilities.supported_sizes
+            else capabilities.supported_sizes[0]
+        )
+        logger.warning(
+            "Size %r not supported by %s, using %s", size, model, fallback
+        )
+        return fallback
+
     def get_model_capabilities(self, model_id: str) -> ModelCapability | None:
         """Get capabilities for a specific OpenAI model."""
         return self.SUPPORTED_MODELS.get(model_id)
+
+    def validate_model_params(
+        self, model: str, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Normalize params, resolving size so metadata and cache reflect
+        what will actually be sent to the API (custom sizes that fail the
+        model's constraints are downgraded to a supported fallback here,
+        not silently rewritten later)."""
+        # Normalize size BEFORE delegating to super() — for models without
+        # supports_custom_sizes, the base validator does an exact-match check
+        # against supported_sizes and would downgrade whitespace/case variants
+        # (e.g. "  1024X1024  ") to the default.
+        capabilities = self.get_model_capabilities(model)
+        normalized_size: str | None = None
+        params = dict(params)
+        if capabilities and "size" in params:
+            raw = params["size"]
+            # Unwrap enums (ImageSize etc.) — str(enum) gives "Class.MEMBER"
+            # for non-StrEnum classes, not the underlying value.
+            normalized_size = raw.value if hasattr(raw, "value") else raw
+            if isinstance(normalized_size, str):
+                normalized_size = normalized_size.strip().lower()
+            params["size"] = normalized_size
+
+        params = super().validate_model_params(model, params)
+
+        if capabilities and normalized_size is not None:
+            params["size"] = self._resolve_size(
+                normalized_size, capabilities, model
+            )
+        return params
 
     async def generate_image(
         self,
@@ -134,13 +267,7 @@ class OpenAIProvider(LLMProvider):
             request_params["moderation"] = moderation
 
         # Add size parameter
-        if size in capabilities.supported_sizes:
-            request_params["size"] = size
-        else:
-            request_params["size"] = capabilities.supported_sizes[0]
-            self._logger.warning(
-                f"Size '{size}' not supported, using {request_params['size']}"
-            )
+        request_params["size"] = self._resolve_size(size, capabilities, model)
 
         # Add style parameter if supported
         if capabilities.supports_style:
@@ -256,10 +383,7 @@ class OpenAIProvider(LLMProvider):
             request_params["mask"] = mask_file
 
         # Add size parameter
-        if size in capabilities.supported_sizes:
-            request_params["size"] = size
-        else:
-            request_params["size"] = capabilities.supported_sizes[0]
+        request_params["size"] = self._resolve_size(size, capabilities, model)
 
         # Add gpt-image-1 family specific parameters
         if model.startswith("gpt-image-"):
@@ -357,27 +481,13 @@ class OpenAIProvider(LLMProvider):
     ) -> dict[str, Any]:
         """Estimate cost for OpenAI image generation."""
 
-        # OpenAI pricing
-        token_pricing = {
-            "gpt-image-1": {
-                "text_input_per_1m_tokens": 5.0,
-                "image_output_per_1m_tokens": 40.0,
-                "tokens_per_image": 1750,
-            },
-            "gpt-image-1.5": {
-                "text_input_per_1m_tokens": 4.0,
-                "image_output_per_1m_tokens": 32.0,
-                "tokens_per_image": 1750,
-            },
-        }
-
         fixed_pricing = {
             "dall-e-3": {"cost_per_image": 0.04},
             "dall-e-2": {"cost_per_image": 0.02},
         }
 
-        if model in token_pricing:
-            model_pricing = token_pricing[model]
+        if model in GPT_IMAGE_TOKEN_PRICING:
+            model_pricing = GPT_IMAGE_TOKEN_PRICING[model]
             text_tokens = len(prompt.split()) * 1.3  # Rough approximation
             text_cost = (text_tokens / 1_000_000) * model_pricing[
                 "text_input_per_1m_tokens"

--- a/image_gen_mcp/resources/models/gpt-image-2.json
+++ b/image_gen_mcp/resources/models/gpt-image-2.json
@@ -7,7 +7,7 @@
     "Image Editing: Precise mask-based editing up to 4K (3840x2160)",
     "Flexible Sizes: Any WxH where both edges are multiples of 16 (max edge 3840px, aspect <=3:1, 655,360 <= total pixels <= 8,294,400)",
     "Multiple Formats: PNG, JPEG, WebP output formats",
-    "Background Control: transparent, opaque, auto",
+    "Background Control: auto, opaque (transparent not supported on gpt-image-2)",
     "Compression: 0-100% for JPEG/WebP formats",
     "Superior Text Rendering: High accuracy for text within images",
     "High-Fidelity Image Inputs: Improved preservation of faces and logos during edits"
@@ -44,7 +44,7 @@
     "WebP"
   ],
   "features": {
-    "background_control": "transparent, opaque, auto",
+    "background_control": "auto, opaque (transparent backgrounds are not supported on gpt-image-2; use gpt-image-1 or gpt-image-1.5 for transparency)",
     "compression": "0-100% for JPEG/WebP",
     "moderation": "auto, low content filtering",
     "flexible_sizing": "Any dimensions within the model's size constraints"

--- a/image_gen_mcp/resources/models/gpt-image-2.json
+++ b/image_gen_mcp/resources/models/gpt-image-2.json
@@ -1,0 +1,64 @@
+{
+  "model_id": "gpt-image-2",
+  "name": "GPT-Image-2",
+  "version": "2.0",
+  "capabilities": [
+    "Text-to-Image Generation: State-of-the-art image quality with improved prompt adherence over gpt-image-1.5",
+    "Image Editing: Precise mask-based editing up to 4K (3840x2160)",
+    "Flexible Sizes: Any WxH where both edges are multiples of 16 (max edge 3840px, aspect <=3:1, 655,360 <= total pixels <= 8,294,400)",
+    "Multiple Formats: PNG, JPEG, WebP output formats",
+    "Background Control: transparent, opaque, auto",
+    "Compression: 0-100% for JPEG/WebP formats",
+    "Superior Text Rendering: High accuracy for text within images",
+    "High-Fidelity Image Inputs: Improved preservation of faces and logos during edits"
+  ],
+  "pricing": {
+    "text_input": "$5 per 1M tokens",
+    "cached_text_input": "$1.25 per 1M tokens",
+    "image_input": "$8 per 1M tokens",
+    "cached_image_input": "$2 per 1M tokens",
+    "image_output": "$30 per 1M tokens (~1750 tokens per image)",
+    "per_image_range": "$0.005 (low) to $0.211 (high)"
+  },
+  "rate_limits": {
+    "default": "Tier-dependent: 5 IPM (tier 1) to 250 IPM (tier 5)",
+    "configurable": "Per organization settings",
+    "automatic_retry": "Built-in backoff logic"
+  },
+  "size_options": [
+    "1024x1024",
+    "1536x1024 (landscape)",
+    "1024x1536 (portrait)",
+    "3840x2160 (4K landscape)",
+    "Custom: any WxH where both are multiples of 16, max edge 3840, aspect <= 3:1, 655,360 <= pixels <= 8,294,400"
+  ],
+  "quality_levels": [
+    "auto",
+    "high",
+    "medium",
+    "low"
+  ],
+  "formats": [
+    "PNG",
+    "JPEG",
+    "WebP"
+  ],
+  "features": {
+    "background_control": "transparent, opaque, auto",
+    "compression": "0-100% for JPEG/WebP",
+    "moderation": "auto, low content filtering",
+    "flexible_sizing": "Any dimensions within the model's size constraints"
+  },
+  "best_practices": [
+    "Use 3840x2160 for hero / print-ready assets when budget allows",
+    "Choose 'low' quality for thumbnails and iteration (~$0.005/image)",
+    "Use JPEG/WebP with compression 75-90 for web delivery",
+    "Leverage cached-token pricing by re-using stable system prompts",
+    "Save image IDs from tool responses to access images later via resources"
+  ],
+  "examples": [
+    "generate_image(prompt='A serene mountain landscape at sunset', model='gpt-image-2', size='3840x2160', quality='high')",
+    "generate_image(prompt='Logo mockup on a white background', model='gpt-image-2', size='2048x1152', quality='medium')",
+    "edit_image(image_data='data:image/png;base64,...', prompt='Add a rainbow to the sky', model='gpt-image-2')"
+  ]
+}

--- a/image_gen_mcp/resources/models/gpt-image-2.json
+++ b/image_gen_mcp/resources/models/gpt-image-2.json
@@ -7,7 +7,7 @@
     "Image Editing: Precise mask-based editing up to 4K (3840x2160)",
     "Flexible Sizes: Any WxH where both edges are multiples of 16 (max edge 3840px, aspect <=3:1, 655,360 <= total pixels <= 8,294,400)",
     "Multiple Formats: PNG, JPEG, WebP output formats",
-    "Background Control: auto, opaque (transparent not supported on gpt-image-2)",
+    "Background Control: auto, opaque (transparent is accepted but auto-downgraded — gpt-image-2 has no native transparency support)",
     "Compression: 0-100% for JPEG/WebP formats",
     "Superior Text Rendering: High accuracy for text within images",
     "High-Fidelity Image Inputs: Improved preservation of faces and logos during edits"
@@ -44,7 +44,7 @@
     "WebP"
   ],
   "features": {
-    "background_control": "auto, opaque (transparent backgrounds are not supported on gpt-image-2; use gpt-image-1 or gpt-image-1.5 for transparency)",
+    "background_control": "auto, opaque. Callers may pass 'transparent' for interface consistency across gpt-image-* models, but it is auto-downgraded to 'auto' since gpt-image-2 has no native transparency support — use gpt-image-1 or gpt-image-1.5 when transparency is required",
     "compression": "0-100% for JPEG/WebP",
     "moderation": "auto, low content filtering",
     "flexible_sizing": "Any dimensions within the model's size constraints"

--- a/image_gen_mcp/tools/image_editing.py
+++ b/image_gen_mcp/tools/image_editing.py
@@ -173,9 +173,13 @@ class ImageEditingTool:
             # Decode base64 image data
             image_bytes = base64.b64decode(edited_image_data.b64_json)
 
-            # Estimate cost
+            # Estimate cost (quality/size-aware for gpt-image-2)
             cost_info = self.openai_client.estimate_cost(
-                prompt, 1, model=self.settings.images.default_model
+                prompt,
+                1,
+                model=self.settings.images.default_model,
+                quality=quality,
+                size=size,
             )
 
             # Add actual usage if available

--- a/image_gen_mcp/tools/image_editing.py
+++ b/image_gen_mcp/tools/image_editing.py
@@ -6,6 +6,7 @@ import uuid
 from typing import Any
 
 from ..config.settings import Settings
+from ..providers.openai import OpenAIProvider
 from ..storage.manager import ImageStorageManager
 from ..utils.cache import CacheManager
 from ..utils.path_utils import build_image_url_path
@@ -119,6 +120,14 @@ class ImageEditingTool:
         # Generate task ID for tracking
         task_id = str(uuid.uuid4())
 
+        # Normalize size against the model's capabilities so the cache key and
+        # persisted metadata reflect what will actually be sent to the API
+        # (invalid custom sizes fall back to the supported default).
+        model = self.settings.images.default_model
+        capabilities = OpenAIProvider.SUPPORTED_MODELS.get(model)
+        if capabilities is not None:
+            size = OpenAIProvider._resolve_size(size, capabilities, model)
+
         # Check cache first (using hash of image data)
         cache_params = {
             "image_data": image_data,
@@ -129,7 +138,7 @@ class ImageEditingTool:
             "output_format": output_format,
             "compression": compression,
             "background": background,
-            "model": self.settings.images.default_model,
+            "model": model,
         }
 
         cached_result = await self.cache_manager.get_image_edit(**cache_params)
@@ -165,7 +174,9 @@ class ImageEditingTool:
             image_bytes = base64.b64decode(edited_image_data.b64_json)
 
             # Estimate cost
-            cost_info = self.openai_client.estimate_cost(prompt, 1)
+            cost_info = self.openai_client.estimate_cost(
+                prompt, 1, model=self.settings.images.default_model
+            )
 
             # Add actual usage if available
             if hasattr(response, "usage") and response.usage:

--- a/image_gen_mcp/tools/image_generation.py
+++ b/image_gen_mcp/tools/image_generation.py
@@ -275,8 +275,14 @@ class ImageGenerationTool:
                 n=1,
             )
 
-            # Estimate cost
-            cost_info = provider.estimate_cost(target_model, prompt, 1)
+            # Estimate cost (quality/size-aware for gpt-image-2)
+            cost_info = provider.estimate_cost(
+                target_model,
+                prompt,
+                1,
+                quality=validated_params.get("quality", quality_str),
+                size=validated_params.get("size", size_str),
+            )
 
             # Prepare metadata
             metadata = {

--- a/image_gen_mcp/types/enums.py
+++ b/image_gen_mcp/types/enums.py
@@ -19,6 +19,7 @@ IMAGE_SIZE_DESCRIPTIONS = {
     "1024x1024": "Square format (1:1 ratio)",
     "1536x1024": "Landscape format (3:2 ratio)",
     "1024x1536": "Portrait format (2:3 ratio)",
+    "3840x2160": "4K landscape (16:9 ratio, gpt-image-2 only)",
 }
 
 IMAGE_STYLE_DESCRIPTIONS = {
@@ -79,6 +80,7 @@ class ImageSize(str, Enum):
     SQUARE = "1024x1024"
     LANDSCAPE = "1536x1024"
     PORTRAIT = "1024x1536"
+    ULTRA_HD = "3840x2160"
     AUTO = "auto"
 
     @property

--- a/image_gen_mcp/utils/openai_client.py
+++ b/image_gen_mcp/utils/openai_client.py
@@ -8,7 +8,11 @@ from openai import AsyncOpenAI
 from openai.types.images_response import ImagesResponse
 
 from ..config.settings import OpenAISettings
-from ..providers.openai import GPT_IMAGE_TOKEN_PRICING, OpenAIProvider
+from ..providers.openai import (
+    GPT_IMAGE_TOKEN_PRICING,
+    OpenAIProvider,
+    _gpt_image_2_tokens_per_image,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -158,8 +162,16 @@ class OpenAIClientManager:
         prompt: str,
         image_count: int = 1,
         model: str = "gpt-image-2",
+        quality: str = "auto",
+        size: str = "1024x1024",
     ) -> dict[str, Any]:
-        """Estimate the cost of image generation."""
+        """Estimate the cost of image generation.
+
+        For gpt-image-2 the per-image token count is approximated by
+        quality tier scaled to pixel count (see OpenAIProvider). Results
+        are rough — use OpenAIProvider.estimate_cost on the active
+        provider instance for the authoritative per-model breakdown.
+        """
 
         pricing = GPT_IMAGE_TOKEN_PRICING.get(model)
         if pricing is None:
@@ -183,7 +195,10 @@ class OpenAIClientManager:
                     "image_output_cost": 0.0,
                 },
             }
-        tokens_per_image = pricing["tokens_per_image"]
+        if model == "gpt-image-2":
+            tokens_per_image = _gpt_image_2_tokens_per_image(quality, size)
+        else:
+            tokens_per_image = pricing["tokens_per_image"]
 
         # Rough token estimation (actual tokenization may vary)
         text_tokens = len(prompt.split()) * 1.3

--- a/image_gen_mcp/utils/openai_client.py
+++ b/image_gen_mcp/utils/openai_client.py
@@ -70,7 +70,12 @@ class OpenAIClientManager:
                 {
                     "style": style,
                     "output_format": output_format,
-                    "background": background,
+                    # Downgrade model-incompatible background values
+                    # (e.g. transparent on gpt-image-2) via the same
+                    # resolver used by OpenAIProvider.
+                    "background": OpenAIProvider._resolve_background(
+                        background, model
+                    ),
                 }
             )
 
@@ -116,9 +121,7 @@ class OpenAIClientManager:
 
         # Normalize size against the model's capabilities so invalid custom
         # sizes (e.g. "9999x9999") fall back locally instead of failing at
-        # the remote API. generate_image() in this class is currently
-        # bypassed by the provider-registry path and so doesn't need the
-        # same treatment here.
+        # the remote API.
         capabilities = OpenAIProvider.SUPPORTED_MODELS.get(model)
         if capabilities is not None:
             size = OpenAIProvider._resolve_size(size, capabilities, model)
@@ -138,7 +141,11 @@ class OpenAIClientManager:
         if model.startswith("gpt-image-"):
             request_params["quality"] = quality
             request_params["output_format"] = output_format
-            request_params["background"] = background
+            # Same background downgrade as generate_image / OpenAIProvider
+            # so transparent on gpt-image-2 never hits the real API.
+            request_params["background"] = OpenAIProvider._resolve_background(
+                background, model
+            )
             if output_format in ["jpeg", "webp"] and compression < 100:
                 request_params["output_compression"] = compression
 

--- a/image_gen_mcp/utils/openai_client.py
+++ b/image_gen_mcp/utils/openai_client.py
@@ -8,6 +8,7 @@ from openai import AsyncOpenAI
 from openai.types.images_response import ImagesResponse
 
 from ..config.settings import OpenAISettings
+from ..providers.openai import GPT_IMAGE_TOKEN_PRICING, OpenAIProvider
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +39,7 @@ class OpenAIClientManager:
     async def generate_image(
         self,
         prompt: str,
-        model: str = "gpt-image-1.5",
+        model: str = "gpt-image-2",
         quality: str = "auto",
         size: str = "1536x1024",
         style: str = "vivid",
@@ -90,7 +91,7 @@ class OpenAIClientManager:
         image_data: str | bytes,
         prompt: str,
         mask_data: str | bytes | None = None,
-        model: str = "gpt-image-1.5",
+        model: str = "gpt-image-2",
         quality: str = "auto",
         size: str = "1536x1024",
         output_format: str = "png",
@@ -109,7 +110,15 @@ class OpenAIClientManager:
         if mask_data:
             _, _, mask_file = prepare_image_upload(mask_data)
 
-        # The /v1/images/edits endpoint supports gpt-image-1.5, gpt-image-1, dall-e-2.
+        # Normalize size against the model's capabilities so invalid custom
+        # sizes (e.g. "9999x9999") fall back locally instead of failing at
+        # the remote API. generate_image() in this class is currently
+        # bypassed by the provider-registry path and so doesn't need the
+        # same treatment here.
+        capabilities = OpenAIProvider.SUPPORTED_MODELS.get(model)
+        if capabilities is not None:
+            size = OpenAIProvider._resolve_size(size, capabilities, model)
+
         request_params = {
             "model": model,
             "image": image_file,
@@ -144,24 +153,52 @@ class OpenAIClientManager:
             logger.error(f"Error editing image: {e}")
             raise
 
-    def estimate_cost(self, prompt: str, image_count: int = 1) -> dict[str, Any]:
+    def estimate_cost(
+        self,
+        prompt: str,
+        image_count: int = 1,
+        model: str = "gpt-image-2",
+    ) -> dict[str, Any]:
         """Estimate the cost of image generation."""
 
+        pricing = GPT_IMAGE_TOKEN_PRICING.get(model)
+        if pricing is None:
+            # Non-gpt-image models (e.g. dall-e-*) use per-image pricing that
+            # this helper doesn't know about. Return a zero estimate rather
+            # than silently reporting gpt-image-2 rates, and log so callers
+            # notice. For accurate per-model cost data, use
+            # OpenAIProvider.estimate_cost.
+            logger.warning(
+                "estimate_cost called with unsupported model %r; "
+                "returning zero cost. Use OpenAIProvider.estimate_cost for "
+                "non-gpt-image models.",
+                model,
+            )
+            return {
+                "estimated_cost_usd": 0.0,
+                "text_input_tokens": 0,
+                "image_output_tokens": 0,
+                "breakdown": {
+                    "text_input_cost": 0.0,
+                    "image_output_cost": 0.0,
+                },
+            }
+        tokens_per_image = pricing["tokens_per_image"]
+
         # Rough token estimation (actual tokenization may vary)
-        text_tokens = len(prompt.split()) * 1.3  # Rough approximation
-
-        # gpt-image-1.5 pricing (20% cheaper than gpt-image-1)
-        text_input_cost = (text_tokens / 1_000_000) * 4.0  # $4 per 1M tokens
+        text_tokens = len(prompt.split()) * 1.3
+        text_input_cost = (
+            text_tokens / 1_000_000
+        ) * pricing["text_input_per_1m_tokens"]
         image_output_cost = (
-            image_count * 1750 / 1_000_000
-        ) * 32.0  # ~1750 tokens per image, $32 per 1M
-
+            image_count * tokens_per_image / 1_000_000
+        ) * pricing["image_output_per_1m_tokens"]
         total_cost = text_input_cost + image_output_cost
 
         return {
             "estimated_cost_usd": round(total_cost, 4),
             "text_input_tokens": int(text_tokens),
-            "image_output_tokens": 1750 * image_count,
+            "image_output_tokens": int(tokens_per_image * image_count),
             "breakdown": {
                 "text_input_cost": round(text_input_cost, 4),
                 "image_output_cost": round(image_output_cost, 4),

--- a/image_gen_mcp/utils/validators.py
+++ b/image_gen_mcp/utils/validators.py
@@ -179,8 +179,22 @@ def validate_image_quality(value: Any) -> ImageQuality:
     return normalize_enum_value(value, ImageQuality, ImageQuality.AUTO)
 
 
-def validate_image_size(value: Any) -> ImageSize:
-    """Validate and normalize image size parameter."""
+def validate_image_size(value: Any) -> ImageSize | str:
+    """Validate and normalize image size parameter.
+
+    Raw ``WIDTHxHEIGHT`` strings that don't map to a standard ``ImageSize``
+    are passed through unchanged so providers that support custom sizes
+    (e.g. ``gpt-image-2``) can apply their own constraints downstream.
+    """
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if "x" in normalized:
+            parts = normalized.split("x", 1)
+            if len(parts) == 2 and all(part.isdigit() for part in parts):
+                for member in ImageSize:
+                    if member.value == normalized:
+                        return member
+                return normalized
     return normalize_enum_value(value, ImageSize, ImageSize.LANDSCAPE)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,7 @@ def mock_cache_settings():
 def mock_image_settings():
     """Mock image settings for testing."""
     return ImageSettings(
-        default_model="gpt-image-1.5",
+        default_model="gpt-image-2",
         default_quality="auto",
         default_size="1024x1024",
         default_style="vivid",

--- a/tests/integration/test_server_integration.py
+++ b/tests/integration/test_server_integration.py
@@ -138,6 +138,7 @@ class TestModelRegistry:
         assert len(models) > 0
         assert "gpt-image-1" in models
         assert "gpt-image-1.5" in models
+        assert "gpt-image-2" in models
 
     @pytest.mark.asyncio
     async def test_get_model_info(self):
@@ -150,6 +151,15 @@ class TestModelRegistry:
         assert model_info.version
         assert model_info.capabilities
         assert isinstance(model_info.capabilities, list)
+
+    @pytest.mark.asyncio
+    async def test_get_model_info_gpt_image_2(self):
+        """Test getting gpt-image-2 model info including 4K size support."""
+        model_info = await model_registry.get_model_info("gpt-image-2")
+
+        assert model_info is not None
+        assert model_info.model_id == "gpt-image-2"
+        assert any("3840x2160" in size for size in model_info.size_options)
 
     @pytest.mark.asyncio
     async def test_get_model_info_nonexistent(self):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -274,11 +274,23 @@ class TestImageSettings:
             settings = ImageSettings(default_quality=quality)
             assert settings.default_quality == quality
 
-        # Valid size values (presets and arbitrary WxH both accepted; the
-        # provider validates at request time for model-specific constraints).
-        for size in ["1024x1024", "1536x1024", "1024x1536", "3840x2160", "2048x1152"]:
+        # Valid size values: 'auto', presets, and arbitrary well-formed WxH.
+        # Model-specific constraints are enforced by the provider at request
+        # time; the settings validator only rejects malformed strings.
+        for size in [
+            "auto",
+            "1024x1024",
+            "1536x1024",
+            "1024x1536",
+            "3840x2160",
+            "2048x1152",
+        ]:
             settings = ImageSettings(default_size=size)
             assert settings.default_size == size
+
+        # Whitespace and case are normalized.
+        assert ImageSettings(default_size="AUTO").default_size == "auto"
+        assert ImageSettings(default_size="  1600X896  ").default_size == "1600x896"
 
         # Valid style values
         for style in ["vivid", "natural"]:
@@ -291,6 +303,12 @@ class TestImageSettings:
 
         with pytest.raises(ValidationError):
             ImageSettings(default_style="invalid")
+
+        # Malformed default_size should fail fast at startup — gibberish must
+        # not silently survive config validation.
+        for bad in ["foo", "1024", "1024x", "xx1024", "0x1024", "", "1024x-10"]:
+            with pytest.raises(ValidationError):
+                ImageSettings(default_size=bad)
 
         # Test compression validation
         with pytest.raises(ValidationError):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -239,7 +239,7 @@ class TestImageSettings:
         """Test image settings with default values."""
         settings = ImageSettings()
 
-        assert settings.default_model == "gpt-image-1.5"
+        assert settings.default_model == "gpt-image-2"
         assert settings.default_quality == "auto"
         assert settings.default_size == "1536x1024"
         assert settings.default_style == "vivid"
@@ -274,8 +274,9 @@ class TestImageSettings:
             settings = ImageSettings(default_quality=quality)
             assert settings.default_quality == quality
 
-        # Valid size values
-        for size in ["1024x1024", "1536x1024", "1024x1536"]:
+        # Valid size values (presets and arbitrary WxH both accepted; the
+        # provider validates at request time for model-specific constraints).
+        for size in ["1024x1024", "1536x1024", "1024x1536", "3840x2160", "2048x1152"]:
             settings = ImageSettings(default_size=size)
             assert settings.default_size == size
 
@@ -287,9 +288,6 @@ class TestImageSettings:
         # Invalid values should raise validation errors
         with pytest.raises(ValidationError):
             ImageSettings(default_quality="invalid")
-
-        with pytest.raises(ValidationError):
-            ImageSettings(default_size="invalid")
 
         with pytest.raises(ValidationError):
             ImageSettings(default_style="invalid")

--- a/tests/unit/test_openai_provider.py
+++ b/tests/unit/test_openai_provider.py
@@ -1,0 +1,167 @@
+"""Unit tests for OpenAI provider, especially gpt-image-2 capabilities."""
+
+import pytest
+
+from image_gen_mcp.providers.base import ProviderConfig
+from image_gen_mcp.providers.openai import OpenAIProvider
+
+
+@pytest.fixture
+def provider():
+    return OpenAIProvider(ProviderConfig(api_key="sk-test", enabled=True))
+
+
+class TestGptImage2Registration:
+    def test_gpt_image_2_registered(self):
+        assert "gpt-image-2" in OpenAIProvider.SUPPORTED_MODELS
+
+    def test_gpt_image_2_capabilities(self):
+        cap = OpenAIProvider.SUPPORTED_MODELS["gpt-image-2"]
+        assert cap.supports_custom_sizes is True
+        assert cap.supports_background is True
+        assert cap.supports_compression is True
+        assert cap.size_constraints is not None
+        assert cap.size_constraints["multiple_of"] == 16
+        assert cap.size_constraints["max_edge"] == 3840
+        assert cap.size_constraints["max_aspect_ratio"] == 3.0
+        assert "3840x2160" in cap.supported_sizes
+
+    def test_gpt_image_1_still_has_fixed_sizes(self):
+        """Regression: legacy gpt-image-1 / 1.5 remain preset-only."""
+        for mid in ("gpt-image-1", "gpt-image-1.5"):
+            cap = OpenAIProvider.SUPPORTED_MODELS[mid]
+            assert cap.supports_custom_sizes is False
+            assert cap.size_constraints is None
+
+
+class TestValidateCustomSize:
+    constraints = {
+        "multiple_of": 16,
+        "max_edge": 3840,
+        "max_aspect_ratio": 3.0,
+        "min_pixels": 655_360,
+        "max_pixels": 8_294_400,
+    }
+
+    @pytest.mark.parametrize(
+        "size",
+        ["1024x1024", "3840x2160", "2048x1152", "1600x896", "1536x1024"],
+    )
+    def test_valid_sizes(self, size):
+        assert OpenAIProvider._validate_custom_size(size, self.constraints) is True
+
+    @pytest.mark.parametrize(
+        "size,reason",
+        [
+            ("1000x1000", "not multiple of 16"),
+            ("4096x2160", "edge exceeds 3840"),
+            ("3840x1024", "aspect ratio 3.75 exceeds 3.0 limit"),
+            ("512x512", "too few pixels"),
+            ("garbage", "malformed"),
+            ("16x16", "too few pixels"),
+            ("", "empty string"),
+            ("1024", "missing dimension"),
+        ],
+    )
+    def test_invalid_sizes(self, size, reason):
+        valid = OpenAIProvider._validate_custom_size(size, self.constraints)
+        assert valid is False, reason
+
+
+class TestEstimateCostGptImage2:
+    def test_cost_uses_30_per_1m(self, provider):
+        result = provider.estimate_cost("gpt-image-2", "a red circle", image_count=1)
+        # 1750 tokens/image * $30/1M = $0.0525 per image, plus tiny text cost
+        image_cost = result["breakdown"]["image_output_cost"]
+        assert image_cost == pytest.approx(0.0525, abs=1e-4)
+        assert result["estimated_cost_usd"] > 0
+        assert result["provider"] == "openai"
+        assert result["model"] == "gpt-image-2"
+
+    def test_cost_cheaper_than_gpt_image_1_5(self, provider):
+        prompt = "a blue square on a white background"
+        v2 = provider.estimate_cost("gpt-image-2", prompt, 1)["estimated_cost_usd"]
+        v1_5 = provider.estimate_cost("gpt-image-1.5", prompt, 1)["estimated_cost_usd"]
+        assert v2 < v1_5
+
+
+class TestResolveSize:
+    def test_preset_size_passthrough(self, provider):
+        cap = OpenAIProvider.SUPPORTED_MODELS["gpt-image-2"]
+        assert provider._resolve_size("1024x1024", cap, "gpt-image-2") == "1024x1024"
+
+    def test_custom_size_allowed_for_v2(self, provider):
+        cap = OpenAIProvider.SUPPORTED_MODELS["gpt-image-2"]
+        assert provider._resolve_size("2048x1152", cap, "gpt-image-2") == "2048x1152"
+
+    def test_invalid_custom_size_falls_back(self, provider):
+        cap = OpenAIProvider.SUPPORTED_MODELS["gpt-image-2"]
+        assert provider._resolve_size("9999x9999", cap, "gpt-image-2") == "auto"
+
+    def test_custom_size_rejected_for_v1(self, provider):
+        """gpt-image-1 has no custom-size support; non-preset falls back."""
+        cap = OpenAIProvider.SUPPORTED_MODELS["gpt-image-1"]
+        assert provider._resolve_size("2048x1152", cap, "gpt-image-1") == "auto"
+
+
+class TestValidateModelParamsSize:
+    """validate_model_params must resolve the size so metadata and cache
+    keys reflect what is actually sent to the API."""
+
+    def test_invalid_custom_size_normalized(self, provider):
+        params = provider.validate_model_params(
+            "gpt-image-2", {"size": "9999x9999"}
+        )
+        assert params["size"] == "auto"
+
+    def test_valid_custom_size_preserved(self, provider):
+        params = provider.validate_model_params(
+            "gpt-image-2", {"size": "2048x1152"}
+        )
+        assert params["size"] == "2048x1152"
+
+    def test_preset_size_preserved(self, provider):
+        params = provider.validate_model_params(
+            "gpt-image-2", {"size": "1024x1024"}
+        )
+        assert params["size"] == "1024x1024"
+
+    def test_v1_non_preset_falls_back(self, provider):
+        """Legacy gpt-image-1 without custom-size support is normalized
+        to a supported value."""
+        params = provider.validate_model_params(
+            "gpt-image-1", {"size": "2048x1152"}
+        )
+        assert params["size"] in OpenAIProvider.SUPPORTED_MODELS[
+            "gpt-image-1"
+        ].supported_sizes
+
+    def test_enum_size_unwrapped(self, provider):
+        """ImageSize enum values pass through to the underlying WxH string.
+
+        str(ImageSize.LANDSCAPE) returns 'ImageSize.LANDSCAPE' (not the value)
+        because ImageSize is a str/Enum hybrid, not StrEnum. The provider
+        must unwrap to .value so the API sees '1536x1024', not a dotted name.
+        """
+        from image_gen_mcp.types.enums import ImageSize
+
+        params = provider.validate_model_params(
+            "gpt-image-2", {"size": ImageSize.LANDSCAPE}
+        )
+        assert params["size"] == "1536x1024"
+
+    def test_whitespace_and_case_normalized(self, provider):
+        """Raw callers passing non-canonical strings get a normalized value."""
+        params = provider.validate_model_params(
+            "gpt-image-2", {"size": "  1600X896  "}
+        )
+        assert params["size"] == "1600x896"
+
+    def test_whitespace_preset_preserved_on_fixed_size_model(self, provider):
+        """For models without custom-size support, the preset match must
+        survive whitespace/case variants — otherwise super()'s exact match
+        would downgrade "  1024X1024  " to the default before we normalize."""
+        params = provider.validate_model_params(
+            "gpt-image-1", {"size": "  1024X1024  "}
+        )
+        assert params["size"] == "1024x1024"

--- a/tests/unit/test_openai_provider.py
+++ b/tests/unit/test_openai_provider.py
@@ -181,9 +181,12 @@ class TestResolveBackground:
         assert provider._resolve_background("auto", "gpt-image-2") == "auto"
         assert provider._resolve_background("opaque", "gpt-image-2") == "opaque"
 
-    def test_capability_list_excludes_transparent_for_v2(self):
+    def test_capability_list_accepts_transparent_for_v2(self):
+        """transparent is kept as an accepted input for interface
+        consistency across gpt-image-* models; the downgrade happens at
+        the outbound API boundary (tested separately)."""
         cap = OpenAIProvider.SUPPORTED_MODELS["gpt-image-2"]
-        assert "transparent" not in cap.custom_parameters["background"]
+        assert "transparent" in cap.custom_parameters["background"]
         assert "transparent" in (
             OpenAIProvider.SUPPORTED_MODELS["gpt-image-1.5"]
             .custom_parameters["background"]

--- a/tests/unit/test_openai_provider.py
+++ b/tests/unit/test_openai_provider.py
@@ -69,20 +69,125 @@ class TestValidateCustomSize:
 
 
 class TestEstimateCostGptImage2:
-    def test_cost_uses_30_per_1m(self, provider):
-        result = provider.estimate_cost("gpt-image-2", "a red circle", image_count=1)
-        # 1750 tokens/image * $30/1M = $0.0525 per image, plus tiny text cost
-        image_cost = result["breakdown"]["image_output_cost"]
-        assert image_cost == pytest.approx(0.0525, abs=1e-4)
-        assert result["estimated_cost_usd"] > 0
-        assert result["provider"] == "openai"
-        assert result["model"] == "gpt-image-2"
+    """Cost must scale by quality tier and pixel count, not be a fixed number."""
+
+    def test_low_quality_1024_near_005(self, provider):
+        result = provider.estimate_cost(
+            "gpt-image-2", "a red circle",
+            image_count=1, quality="low", size="1024x1024",
+        )
+        # Low-quality 1024x1024 is roughly $0.005 per OpenAI's calculator.
+        assert result["breakdown"]["image_output_cost"] == pytest.approx(
+            0.0051, abs=1e-3
+        )
+        assert result["estimate_accuracy"] == "rough"
+
+    def test_medium_quality_1024_near_041(self, provider):
+        result = provider.estimate_cost(
+            "gpt-image-2", "a red circle",
+            image_count=1, quality="medium", size="1024x1024",
+        )
+        # Medium 1024x1024 ≈ $0.041 per calculator.
+        assert result["breakdown"]["image_output_cost"] == pytest.approx(
+            0.0411, abs=5e-3
+        )
+
+    def test_high_quality_1024_near_165(self, provider):
+        result = provider.estimate_cost(
+            "gpt-image-2", "a red circle",
+            image_count=1, quality="high", size="1024x1024",
+        )
+        # High 1024x1024 ≈ $0.165 per calculator.
+        assert result["breakdown"]["image_output_cost"] == pytest.approx(
+            0.165, abs=0.01
+        )
+
+    def test_size_multiplier_capped_for_large_images(self, provider):
+        """OpenAI's calculator scales sub-linearly: a 4K image costs only
+        ~28% more than 1024x1024 despite the ~8x pixel ratio. Our
+        approximation caps the multiplier at 1.3x to match."""
+        small = provider.estimate_cost(
+            "gpt-image-2", "x", quality="high", size="1024x1024",
+        )["breakdown"]["tokens_per_image"]
+        huge = provider.estimate_cost(
+            "gpt-image-2", "x", quality="high", size="3840x2160",
+        )["breakdown"]["tokens_per_image"]
+        assert huge == int(small * 1.3)
+
+    def test_scales_down_for_small_sizes(self, provider):
+        """Below 1024x1024 the cost should scale down proportionally."""
+        baseline = provider.estimate_cost(
+            "gpt-image-2", "x", quality="low", size="1024x1024",
+        )["breakdown"]["tokens_per_image"]
+        quarter = provider.estimate_cost(
+            "gpt-image-2", "x", quality="low", size="512x512",
+        )["breakdown"]["tokens_per_image"]
+        assert quarter == pytest.approx(baseline / 4, rel=0.02)
+
+    def test_4k_high_quality_near_calculator(self, provider):
+        """High 3840x2160 ≈ $0.211 per OpenAI's calculator."""
+        result = provider.estimate_cost(
+            "gpt-image-2", "x", quality="high", size="3840x2160",
+        )
+        assert result["breakdown"]["image_output_cost"] == pytest.approx(
+            0.211, abs=0.02
+        )
+
+    def test_auto_quality_treated_as_medium(self, provider):
+        auto = provider.estimate_cost(
+            "gpt-image-2", "x", quality="auto", size="1024x1024",
+        )["breakdown"]["tokens_per_image"]
+        medium = provider.estimate_cost(
+            "gpt-image-2", "x", quality="medium", size="1024x1024",
+        )["breakdown"]["tokens_per_image"]
+        assert auto == medium
+
+    def test_breakdown_includes_quality_and_size(self, provider):
+        result = provider.estimate_cost(
+            "gpt-image-2", "x", quality="high", size="2048x1152",
+        )
+        assert result["breakdown"]["quality"] == "high"
+        assert result["breakdown"]["size"] == "2048x1152"
 
     def test_cost_cheaper_than_gpt_image_1_5(self, provider):
         prompt = "a blue square on a white background"
-        v2 = provider.estimate_cost("gpt-image-2", prompt, 1)["estimated_cost_usd"]
-        v1_5 = provider.estimate_cost("gpt-image-1.5", prompt, 1)["estimated_cost_usd"]
+        v2 = provider.estimate_cost(
+            "gpt-image-2", prompt, 1, quality="auto", size="1024x1024",
+        )["estimated_cost_usd"]
+        v1_5 = provider.estimate_cost(
+            "gpt-image-1.5", prompt, 1,
+        )["estimated_cost_usd"]
         assert v2 < v1_5
+
+
+class TestResolveBackground:
+    """gpt-image-2 does not support transparent backgrounds (OpenAI docs)."""
+
+    def test_transparent_downgraded_for_gpt_image_2(self, provider, caplog):
+        import logging
+        caplog.set_level(logging.WARNING)
+        assert provider._resolve_background("transparent", "gpt-image-2") == "auto"
+        assert any(
+            "transparent" in rec.message and "gpt-image-2" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_transparent_preserved_for_gpt_image_1_5(self, provider):
+        # Older gpt-image-* models DO support transparent.
+        for m in ("gpt-image-1", "gpt-image-1.5"):
+            assert provider._resolve_background("transparent", m) == "transparent"
+
+    def test_auto_and_opaque_passthrough(self, provider):
+        assert provider._resolve_background("auto", "gpt-image-2") == "auto"
+        assert provider._resolve_background("opaque", "gpt-image-2") == "opaque"
+
+    def test_capability_list_excludes_transparent_for_v2(self):
+        cap = OpenAIProvider.SUPPORTED_MODELS["gpt-image-2"]
+        assert "transparent" not in cap.custom_parameters["background"]
+        assert "transparent" in (
+            OpenAIProvider.SUPPORTED_MODELS["gpt-image-1.5"]
+            .custom_parameters["background"]
+        )
 
 
 class TestResolveSize:

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -61,10 +62,10 @@ class TestImageGenerationTool:
 
         # Mock provider registry to skip complex provider logic
         mock_generation_tool.provider_registry.get_supported_models = MagicMock(
-            return_value=["gpt-image-1.5"]
+            return_value=["gpt-image-2"]
         )
         mock_generation_tool._get_default_model = MagicMock(
-            return_value="gpt-image-1.5"
+            return_value="gpt-image-2"
         )
 
         # Use MagicMock for the provider object to mock non-async methods and
@@ -117,10 +118,10 @@ class TestImageGenerationTool:
             return_value="http://localhost:3001/images/test_id.png"
         )
         mock_generation_tool.provider_registry.get_supported_models = MagicMock(
-            return_value=["gpt-image-1.5"]
+            return_value=["gpt-image-2"]
         )
         mock_generation_tool._get_default_model = MagicMock(
-            return_value="gpt-image-1.5"
+            return_value="gpt-image-2"
         )
 
         # Mock provider
@@ -184,10 +185,10 @@ class TestImageGenerationTool:
             return_value="http://localhost:3001/images/test_id.png"
         )
         mock_generation_tool.provider_registry.get_supported_models = MagicMock(
-            return_value=["gpt-image-1.5"]
+            return_value=["gpt-image-2"]
         )
         mock_generation_tool._get_default_model = MagicMock(
-            return_value="gpt-image-1.5"
+            return_value="gpt-image-2"
         )
 
         # Mock provider
@@ -235,10 +236,10 @@ class TestImageGenerationTool:
             return_value="http://localhost:3001/images/test_id.jpeg"
         )
         mock_generation_tool.provider_registry.get_supported_models = MagicMock(
-            return_value=["gpt-image-1.5"]
+            return_value=["gpt-image-2"]
         )
         mock_generation_tool._get_default_model = MagicMock(
-            return_value="gpt-image-1.5"
+            return_value="gpt-image-2"
         )
 
         # Mock provider
@@ -281,10 +282,10 @@ class TestImageGenerationTool:
             return_value=None
         )
         mock_generation_tool.provider_registry.get_supported_models = MagicMock(
-            return_value=["gpt-image-1.5"]
+            return_value=["gpt-image-2"]
         )
         mock_generation_tool._get_default_model = MagicMock(
-            return_value="gpt-image-1.5"
+            return_value="gpt-image-2"
         )
 
         # Mock provider with error
@@ -339,10 +340,10 @@ class TestImageGenerationTool:
             return_value="http://localhost:3001/images/stored_id.png"
         )
         mock_generation_tool.provider_registry.get_supported_models = MagicMock(
-            return_value=["gpt-image-1.5"]
+            return_value=["gpt-image-2"]
         )
         mock_generation_tool._get_default_model = MagicMock(
-            return_value="gpt-image-1.5"
+            return_value="gpt-image-2"
         )
 
         # Mock provider
@@ -635,6 +636,55 @@ class TestImageEditingTool:
 
         assert result["image_id"] == "edited_id"
         storage_manager.save_image.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_edit_invalid_custom_size_normalized_for_cache_and_metadata(
+        self, mock_editing_tool, sample_image_data
+    ):
+        """Invalid custom sizes should be normalized before cache lookup and
+        before building the returned metadata, matching what is actually sent
+        to the OpenAI edits API."""
+        # Prepare mocks
+        sample_b64 = sample_image_data.split(",", 1)[1]
+        captured_cache_params: dict[str, Any] = {}
+
+        async def capture_get(**kwargs):
+            captured_cache_params.update(kwargs)
+            return None
+
+        mock_editing_tool.cache_manager.get_image_edit = AsyncMock(side_effect=capture_get)
+        mock_editing_tool.cache_manager.set_image_edit = AsyncMock()
+        mock_editing_tool.storage_manager.save_image = AsyncMock(
+            return_value=("edited_id", "/path/to/image")
+        )
+        mock_editing_tool._build_image_url = MagicMock(
+            return_value="http://localhost:3001/images/edited_id.png"
+        )
+
+        # spec_set deliberately omits .size so getattr(resp, "size", size)
+        # falls back to the normalized local variable.
+        mock_response = MagicMock(spec_set=["data", "usage", "created"])
+        mock_response.data = [MagicMock(b64_json=sample_b64)]
+        mock_response.usage = None
+        mock_response.created = 1234567890
+        mock_editing_tool.openai_client.edit_image.return_value = mock_response
+
+        result = await mock_editing_tool.edit(
+            image_data=sample_image_data,
+            prompt="oversize test",
+            size="9999x9999",
+        )
+
+        # Cache key reflects the normalized size ("auto"), not "9999x9999"
+        assert captured_cache_params["size"] == "auto"
+
+        # Returned metadata uses the normalized size consistently
+        assert result["metadata"]["size"] == "auto"
+        assert result["metadata"]["dimensions"] == "auto"
+
+        # The call to the underlying client also used the normalized size
+        call_kwargs = mock_editing_tool.openai_client.edit_image.call_args.kwargs
+        assert call_kwargs["size"] == "auto"
 
     def test_missing_openai_provider_configuration(
         self, storage_manager, cache_manager

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -652,7 +652,9 @@ class TestImageEditingTool:
             captured_cache_params.update(kwargs)
             return None
 
-        mock_editing_tool.cache_manager.get_image_edit = AsyncMock(side_effect=capture_get)
+        mock_editing_tool.cache_manager.get_image_edit = AsyncMock(
+            side_effect=capture_get
+        )
         mock_editing_tool.cache_manager.set_image_edit = AsyncMock()
         mock_editing_tool.storage_manager.save_image = AsyncMock(
             return_value=("edited_id", "/path/to/image")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -125,6 +125,15 @@ class TestSpecificValidators:
         assert validate_image_size("invalid") == ImageSize.LANDSCAPE
         assert validate_image_size(None) == ImageSize.LANDSCAPE
 
+    def test_validate_image_size_passthrough_custom(self):
+        """Raw WxH strings not in the enum are returned unchanged so
+        providers supporting custom sizes (e.g. gpt-image-2) can validate
+        them against their own constraints."""
+        assert validate_image_size("2048x1152") == "2048x1152"
+        assert validate_image_size("  1600X896  ") == "1600x896"
+        # Malformed WxH still falls back to the default enum value
+        assert validate_image_size("axb") == ImageSize.LANDSCAPE
+
     def test_validate_image_style(self):
         """Test image style validation."""
         assert validate_image_style("vivid") == ImageStyle.VIVID
@@ -604,6 +613,47 @@ class TestOpenAIClientManager:
             organization="org-test123",
             max_retries=mock_openai_settings.max_retries,
             timeout=mock_openai_settings.timeout,
+        )
+
+    @pytest.mark.asyncio
+    @patch("image_gen_mcp.utils.openai_client.AsyncOpenAI")
+    async def test_edit_image_normalizes_invalid_custom_size(
+        self, mock_openai_class, mock_openai_settings
+    ):
+        """Invalid custom edit sizes are downgraded to a supported fallback
+        before the request is sent, matching the generation path."""
+        from unittest.mock import AsyncMock
+
+        mock_response = MagicMock()
+        mock_response.data = [MagicMock(b64_json="Zg==")]
+
+        mock_client = MagicMock()
+        mock_client.images.edit = AsyncMock(return_value=mock_response)
+        mock_openai_class.return_value = mock_client
+
+        manager = OpenAIClientManager(mock_openai_settings)
+
+        png_bytes = (
+            b"\x89PNG\r\n\x1a\n"
+            b"\x00\x00\x00\rIHDR"
+            b"\x00\x00\x00\x01\x00\x00\x00\x01"
+            b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+            b"\x00\x00\x00\rIDATx\x9cc\xfc\xcf\xc0\x00\x00\x00\x03\x00\x01"
+            b"\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
+        import base64 as _b64
+        image_b64 = _b64.b64encode(png_bytes).decode()
+
+        await manager.edit_image(
+            image_data=image_b64,
+            prompt="test",
+            model="gpt-image-2",
+            size="9999x9999",
+        )
+
+        sent_size = mock_client.images.edit.call_args.kwargs["size"]
+        assert sent_size == "auto", (
+            f"Invalid custom size should normalize to fallback, got {sent_size!r}"
         )
 
     @patch("image_gen_mcp.utils.openai_client.AsyncOpenAI")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -656,6 +656,104 @@ class TestOpenAIClientManager:
             f"Invalid custom size should normalize to fallback, got {sent_size!r}"
         )
 
+    @pytest.mark.asyncio
+    @patch("image_gen_mcp.utils.openai_client.AsyncOpenAI")
+    async def test_generate_image_downgrades_transparent_bg_for_v2(
+        self, mock_openai_class, mock_openai_settings
+    ):
+        """background='transparent' is not natively supported by gpt-image-2.
+        OpenAIClientManager.generate_image must downgrade to 'auto' before
+        the outbound API call, matching OpenAIProvider's behavior."""
+        from unittest.mock import AsyncMock
+
+        mock_response = MagicMock()
+        mock_response.data = [MagicMock(b64_json="Zg==")]
+
+        mock_client = MagicMock()
+        mock_client.images.generate = AsyncMock(return_value=mock_response)
+        mock_openai_class.return_value = mock_client
+
+        manager = OpenAIClientManager(mock_openai_settings)
+
+        await manager.generate_image(
+            prompt="a red circle",
+            model="gpt-image-2",
+            background="transparent",
+        )
+
+        sent_bg = mock_client.images.generate.call_args.kwargs["background"]
+        assert sent_bg == "auto", (
+            f"gpt-image-2 should receive background='auto', got {sent_bg!r}"
+        )
+
+    @pytest.mark.asyncio
+    @patch("image_gen_mcp.utils.openai_client.AsyncOpenAI")
+    async def test_generate_image_preserves_transparent_bg_for_v1_5(
+        self, mock_openai_class, mock_openai_settings
+    ):
+        """gpt-image-1 / gpt-image-1.5 natively support transparent — the
+        downgrade must not fire for them."""
+        from unittest.mock import AsyncMock
+
+        mock_response = MagicMock()
+        mock_response.data = [MagicMock(b64_json="Zg==")]
+
+        mock_client = MagicMock()
+        mock_client.images.generate = AsyncMock(return_value=mock_response)
+        mock_openai_class.return_value = mock_client
+
+        manager = OpenAIClientManager(mock_openai_settings)
+
+        await manager.generate_image(
+            prompt="a red circle",
+            model="gpt-image-1.5",
+            background="transparent",
+        )
+
+        sent_bg = mock_client.images.generate.call_args.kwargs["background"]
+        assert sent_bg == "transparent"
+
+    @pytest.mark.asyncio
+    @patch("image_gen_mcp.utils.openai_client.AsyncOpenAI")
+    async def test_edit_image_downgrades_transparent_bg_for_v2(
+        self, mock_openai_class, mock_openai_settings
+    ):
+        """Same downgrade behavior as generate_image but on the edit path —
+        this is the path ImageEditingTool.edit() actually uses."""
+        from unittest.mock import AsyncMock
+
+        mock_response = MagicMock()
+        mock_response.data = [MagicMock(b64_json="Zg==")]
+
+        mock_client = MagicMock()
+        mock_client.images.edit = AsyncMock(return_value=mock_response)
+        mock_openai_class.return_value = mock_client
+
+        manager = OpenAIClientManager(mock_openai_settings)
+
+        png_bytes = (
+            b"\x89PNG\r\n\x1a\n"
+            b"\x00\x00\x00\rIHDR"
+            b"\x00\x00\x00\x01\x00\x00\x00\x01"
+            b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+            b"\x00\x00\x00\rIDATx\x9cc\xfc\xcf\xc0\x00\x00\x00\x03\x00\x01"
+            b"\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
+        import base64 as _b64
+        image_b64 = _b64.b64encode(png_bytes).decode()
+
+        await manager.edit_image(
+            image_data=image_b64,
+            prompt="make it blue",
+            model="gpt-image-2",
+            background="transparent",
+        )
+
+        sent_bg = mock_client.images.edit.call_args.kwargs["background"]
+        assert sent_bg == "auto", (
+            f"gpt-image-2 edit should receive background='auto', got {sent_bg!r}"
+        )
+
     @patch("image_gen_mcp.utils.openai_client.AsyncOpenAI")
     def test_openai_client_custom_settings(
         self, mock_openai_class, mock_openai_settings


### PR DESCRIPTION
- Register gpt-image-2 in OpenAIProvider with support for arbitrary WxH (multiples of 16, max edge 3840, aspect <=3:1, 655,360-8,294,400 pixels).
- Add supports_custom_sizes + size_constraints to ModelCapability and a shared _resolve_size/_validate_custom_size path so invalid sizes are normalized consistently for cache keys, metadata, and the outbound API call.
- Switch default model to gpt-image-2 (cheaper than gpt-image-1.5: \$30 vs \$32 per 1M image output tokens).
- Extract GPT_IMAGE_TOKEN_PRICING to module level so OpenAIProvider and OpenAIClientManager share one pricing source.
- Pass raw WxH strings through validate_image_size so custom sizes can reach the provider layer.
- New model doc (gpt-image-2.json), updated README/SYSTEM_DESIGN/docs, expanded tests covering custom-size validation, cost estimation, and end-to-end normalization on the edit path.